### PR TITLE
Add Devtodev sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ A simple to use TCP and UDP networking library for .NET. Compatible with Unity
 ### Services
 * [Google Play Games plugin for Unity](https://github.com/playgameservices/play-games-plugin-for-unity) - Google Play Games plugin for Unity
 * [line-sdk-unity](https://github.com/line/line-sdk-unity) - Provides a modern way of implementing LINE APIs in Unity games, for iOS and Android.
+* [Devtodev] (https://github.com/devtodev-analytics/unity-sdk) - A full-cycle analytics solution for game developers.
 
 ### Sounds
 * [usfxr](https://github.com/zeh/usfxr) - a C# library used to generate and play game-like procedural audio effects inside Unity. With usfxr, one can easily design and synthesize original sound in real time for actions such as item pickups, jumps, lasers, hits, explosions, and more, without ever leaving the Unity editor.


### PR DESCRIPTION
devtodev (https://www.devtodev.com/) is an analytical platform developed by games industry professionals specifically for game developers. With devtodev, you can convert players into paying users, improve in-game economics, predict churn, revenue and customer lifetime value, as well as analyze and influence user behavior.