### PR TITLE
Sort Services in alphabetical order. Add Playerloop

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,10 +592,11 @@ A simple to use TCP and UDP networking library for .NET. Compatible with Unity
 * [odin-serializer](https://github.com/TeamSirenix/odin-serializer) - Fast, robust, powerful and extendible .NET serializer built for Unity
 
 ### Services
-* [Google Play Games plugin for Unity](https://github.com/playgameservices/play-games-plugin-for-unity) - Google Play Games plugin for Unity
-* [line-sdk-unity](https://github.com/line/line-sdk-unity) - Provides a modern way of implementing LINE APIs in Unity games, for iOS and Android.
 * [Devtodev](https://github.com/devtodev-analytics/unity-sdk) - A full-cycle analytics solution for game developers.
 * [eos_plugin_for_unity](https://github.com/PlayEveryWare/eos_plugin_for_unity) - The eos_plugin_for_unity repository contains the source code for development and support of the Epic Online Services Plugin for Unity (UPM Package) package.
+* [line-sdk-unity](https://github.com/line/line-sdk-unity) - Provides a modern way of implementing LINE APIs in Unity games, for iOS and Android.
+* [Google Play Games plugin for Unity](https://github.com/playgameservices/play-games-plugin-for-unity) - Google Play Games plugin for Unity
+* [Playerloop](https://github.com/playerloop/playerloop-unity) - The fastest way to start collecting bug reports from your players.
 
 ### Sounds
 * [usfxr](https://github.com/zeh/usfxr) - a C# library used to generate and play game-like procedural audio effects inside Unity. With usfxr, one can easily design and synthesize original sound in real time for actions such as item pickups, jumps, lasers, hits, explosions, and more, without ever leaving the Unity editor.


### PR DESCRIPTION
I've ordered the 'Services' chapter in alphabetical order, and I've added Playerloop to the list, with a link to the Unity SDK Github repository