### PR TITLE
Add com.unity.ide.antigravity (Antigravity IDE Unity integration) to Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Custom Nav Mesh Avoidance to replace default one in Unity.
 * [FastScriptReload](https://github.com/handzlikchris/FastScriptReload) - Hot Reload implementation for Unity. Iterate on code insanely fast without breaking play session. Supports any editor. 1. Play 2. Make change 3. See results
 * [unity-cli-plugin](https://github.com/niqibiao/unity-cli-plugin) - AI coding agent plugin for Unity Editor supporting Claude Code and Codex CLI. 40+ commands for scene editing, components, assets, screenshots, and profiling; falls back to a full Roslyn C# REPL via unity-csharpconsole.
 
+* [com.unity.ide.antigravity](https://github.com/BadranRaza/com.unity.ide.antigravity) - Unity Editor integration for Google Antigravity IDE (the VS Code-based code editor split off from the standalone Antigravity 2.0 agent app at I/O 2026). Detects the IDE vs the agent app via resources/app/package.json manifest verification.
 ### Effect and Shaders
 * [Unity 5 Effects](https://github.com/i-saint/Unity5Effects) - Effect storage space for Unity 5.
 * [unity-frosted-glass](https://github.com/andydbc/unity-frosted-glass) - frosted glass material made in unity


### PR DESCRIPTION
Adds a single entry to the `### Editor` section under `## Open Source Repositories`:

> * [com.unity.ide.antigravity](https://github.com/BadranRaza/com.unity.ide.antigravity) - Unity Editor integration for Google Antigravity IDE (the VS Code-based code editor split off from the standalone Antigravity 2.0 agent app at I/O 2026). Detects the IDE vs the agent app via resources/app/package.json manifest verification.

### Context

Google split the Antigravity product line at Google I/O 2026 (May 19, 2026) into a standalone agent-orchestration app (now called "Antigravity") and a separate VS Code-fork code editor ("Antigravity IDE"). Most community Unity packages discovering Antigravity match any `Antigravity*.exe`, so on machines with both products installed Unity often opens the agent app on every script double-click — which has no editor surface and just shows the agent home screen.

This package fixes that by reading `resources/app/package.json` and only accepting installs whose product `name` is exactly `Antigravity IDE`.

- MIT-licensed, Unity 2019.4+
- Latest release: v1.0.8 (May 23, 2026)
- Deep-dive on the bug + fix: https://github.com/BadranRaza/com.unity.ide.antigravity/blob/master/Documentation~/antigravity-2-0-fix.md

Happy to tweak the description / placement if needed. Thanks for maintaining this list!