### PR TITLE
Add Unity-MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Custom Nav Mesh Avoidance to replace default one in Unity.
 * [MonoBehaviourTree](https://github.com/Qriva/MonoBehaviourTree) - Simple event driven Behaviour tree for Unity projects
 * [N:ORCA](https://github.com/Nebukam/com.nebukam.orca) - ORCA / RVO2 Implementation for Unity — Multithreaded using the job system.
 * [jahro-console/unity-agent-skills](https://github.com/jahro-console/unity-agent-skills) - Unity AI agentic skills set
+* [Unity-MCP](https://github.com/IvanMurzak/Unity-MCP) - Open-source MCP server connecting AI agents (Claude, Cursor, GitHub Copilot, Gemini, and more) to the Unity Editor and runtime, with 100+ built-in tools.
 
 ### Analyzer
 * [UnityHeapExplorer](https://github.com/pschraut/UnityHeapExplorer) - A Memory Profiler, Debugger and Analyzer for Unity 2019.3 and newer.


### PR DESCRIPTION
Adds Unity-MCP, an open-source (Apache-2.0) MCP server that connects AI coding agents (Claude, Cursor, GitHub Copilot, Gemini, and others) to the Unity Editor and runtime via Anthropic's Model Context Protocol, with 100+ built-in tools. Maintained at github.com/IvanMurzak/Unity-MCP. Happy to adjust formatting/placement to match this list's conventions — thanks for maintaining it!